### PR TITLE
Remove dividier margin; fixes small inconsistency with NomadNet

### DIFF
--- a/js/micron-parser.js
+++ b/js/micron-parser.js
@@ -264,7 +264,6 @@ class MicronParser {
                         div.style.width = "100%";
                         div.style.whiteSpace = "nowrap";
                         div.style.overflow = "hidden";
-                        div.style.margin = "0.5em 0";
                         this.applySectionIndent(div, state);
 
                         return [div];


### PR DESCRIPTION
Related to #5 , only a partial fix for a separate inconsistency.

Current:
![image](https://github.com/user-attachments/assets/187f655e-95c3-4afc-b0b6-2902e5211b23)

Fixed:
![image](https://github.com/user-attachments/assets/5ca9a49d-620b-4b6d-b259-67c73484acaa)

Notice how the extra spacing around the border above "You can change background ..." is removed.

This fixes an inconsistency when compared to NomadNet's handling of dividers.