### PR TITLE
Patch to fix (mostly) part one of #5

### DIFF
--- a/js/micron-parser.js
+++ b/js/micron-parser.js
@@ -250,6 +250,8 @@ class MicronParser {
                     // if the line is  just "-", do a normal <hr>
                     if (line.length === 1) {
                         const hr = document.createElement("hr");
+                        hr.style.all = "revert";
+                        hr.style.color = "inherit";
                         this.applySectionIndent(hr, state);
                         return [hr];
                     } else {


### PR DESCRIPTION
This should largely fix part 1 of #5 
This may make it harder to fix part 2 of the same issue. May need to use something other than `<hr>` in that case (possibly somehow apply forceMonospace() to the divider and make `-` the same as `--`?), but either way I believe it's a lower priority.

Example:
![image](https://github.com/user-attachments/assets/06b9dc88-235c-450f-810e-0ecfdc3d5860)

Screenshot also displays fixes from #6

This may be mostly a temporary thing if Tailwind is to be disabled in the rendered output.