### PR TITLE
Add back "monospace, monospace"

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,12 +16,12 @@
         }
 
         body {
-            font-family: Roboto Mono Nerd Font, monospace !important;
+            font-family: Roboto Mono Nerd Font, monospace, monospace !important;
             line-height: normal !important;
         }
 
         pre {
-            font-family: Roboto Mono Nerd Font, monospace !important;
+            font-family: Roboto Mono Nerd Font, monospace, monospace !important;
             line-height: normal !important;
         }
     </style>


### PR DESCRIPTION
When RobotoMonoNerdFont-Regular.ttf is missing, having only a single `monospace` makes the font size smaller.

| `monospace` |
| ----- |
| ![image](https://github.com/user-attachments/assets/741018b6-77dd-4865-81d0-59c7d25af6be) |

| `monospace, monospace` |
| ----- |
| ![image](https://github.com/user-attachments/assets/073d899b-346d-43a1-b159-7c74e7af242b) |