### PR TITLE
Apply ForceMonospace to Literals

### DIFF
--- a/js/micron-parser.js
+++ b/js/micron-parser.js
@@ -572,7 +572,11 @@ applyStyleToElement(el, style) {
             if (line === "\\`=") {
                 line = "`=";
             }
-            return [[this.stateToStyle(state), line]];
+            if(this.enableForceMonospace) {
+                return [[this.stateToStyle(state), this.splitAtSpaces(line)]];
+            } else {
+                return [[this.stateToStyle(state), line]];
+            }
         }
 
         let output = [];


### PR DESCRIPTION
### Issue

ForceMonospace is not currently applied to text inside literals/codeblocks resulting in unexpected behavior in certain situations.
This was discovered thanks to the Beleth node, located at `7a27fd528a13d3ac3c3043e950ed3376:/page/index.mu` 

### Current

<img width="1920" height="1036" alt="image" src="https://github.com/user-attachments/assets/4a06f491-4a6f-4fb5-8e0e-70ed8f9fa3e7" />

### Fixed

<img width="1920" height="1036" alt="image" src="https://github.com/user-attachments/assets/22fc0d4b-d5da-4008-8e8d-8690e85d9d4e" />
