### PR TITLE
Fixing Space Insertion Issue

### DIFF
--- a/js/micron-parser.js
+++ b/js/micron-parser.js
@@ -882,9 +882,9 @@ applyStyleToElement(el, style) {
 
     splitAtSpaces(line) {
         let out = "";
-        let wordArr = line.split(" ");
+        let wordArr = line.split(/(?<= )/g);
         for (let i = 0; i < wordArr.length; i++) {
-            out += "<span class='Mu-mws'>" + this.forceMonospace(wordArr[i] + " ") + "</span>";
+            out += "<span class='Mu-mws'>" + this.forceMonospace(wordArr[i]) + "</span>";
         }
         return out;
     }


### PR DESCRIPTION
forceMonospace was previously not applied to spaces due to a word-wrapping issue.
This uses commit moves where the space is re-added in order to fix that issue without messing with word-wrapping *too* much.