### PR TITLE
Temporarily comment out the FT truecolor tag for compatibility

### DIFF
--- a/js/micron-parser.js
+++ b/js/micron-parser.js
@@ -694,15 +694,18 @@ applyStyleToElement(el, style, defaultBg = "default") {
                             state.fg_color = color;
                             skip = 8;
                             break;
-                        }  
-
-                        if (line[i+1] == "T" && line.length >= i + 8) { // "this page doesnt work on nomadnet" truecolor tag (`FTxxxxxx)
-                            
+                        }
+                  
+                        /*
+                        // Until NomadNet supports the `FTaaaaaa truecolor Micron tag, please do not uncomment.
+                        if (line[i+1] == "T" && line.length >= i + 8) {
                             let color = line.substr(i + 2, 6);
                             state.fg_color = color;
                             skip = 7;
                             break;
                         }
+                        */
+                  
                         // next 3 chars => fg color
                         if (line.length >= i + 4) {
 
@@ -723,6 +726,9 @@ applyStyleToElement(el, style, defaultBg = "default") {
                             flushPart(); // flush current part when background color changes
                             break;
                         }  
+                        
+                        /*
+                        // Until NomadNet supports the `BTaaaaaa truecolor Micron tag, please do not uncomment.
                         if (line[i+1] == "T" && line.length >= i + 8) { // "this page doesnt work on nomadnet" truecolor tag (`BTxxxxxx)
                             let color = line.substr(i + 2, 6);
                             state.bg_color = color;
@@ -730,6 +736,8 @@ applyStyleToElement(el, style, defaultBg = "default") {
                             flushPart(); // flush current part when background color changes
                             break;
                         }
+                        */
+                  
                         // next 3 chars => bg color
                         if (line.length >= i + 4) {
                             let color = line.substr(i + 1, 3);


### PR DESCRIPTION
Since NomadNet doesn’t yet support the ``` `FT ``` tag, I suggest commenting it out until it, or an alternative, is added to NomadNet.

I proposed the backwards compatible True color format implemented in #21 over a Matrix DM:
> If you can at least keep it backwards compatible, I'd say it's probably fine.
> You could make it so that ``` `Fbdf`Face``` represents `#abcdef` and that would actually be backwards compatible.

The ``` `FT ``` implementation isn’t backwards compatible because ``` `FTaaaaaa``` would likely show up as either `aaaa` or `Taaaaaa` depending on the parser implementation.
Because so many NomadNet pages are built and tested with micron-parser-js, I think it’s ill-advised to support a feature which breaks NomadNet support so badly, since it’ll work when testing but not in NomadNet.

That is why I propose temporarily commenting out support for the ``` `FT ``` tag until NomadNet gets support for it. (I believe a patch has been sent to Mark; we’ll see what he says)