### PR TITLE
Fix divider left and right margins

### DIFF
--- a/js/micron-parser.js
+++ b/js/micron-parser.js
@@ -308,7 +308,7 @@ class MicronParser {
                         const hr = document.createElement("hr");
                         hr.style.all = "revert";
                         hr.style.borderColor = this.colorToCss(state.fg_color);
-                        hr.style.margin = "0.5em 0.5em 0.5em 0.5em";
+                        hr.style.margin = "0.5em 0 0.5em 0";
                         hr.style.boxShadow = "0 0 0 0.5em " + this.colorToCss(state.bg_color);
                         this.applySectionIndent(hr, state);
                         return [hr];


### PR DESCRIPTION
Removed extra margin on the left and right side of dividers as the text indenting inconsistencies that made it necessary have been fixed.

Previous:
<img width="569" height="496" alt="image" src="https://github.com/user-attachments/assets/84772cf2-c20b-473d-94ea-5485d2482c0e" />

With fix:
<img width="569" height="496" alt="image" src="https://github.com/user-attachments/assets/277ff4d3-fa92-4884-9780-f83fc25bf598" />
